### PR TITLE
OPS-6813 Pin provider v5.8.2 to fix CAA records

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Terraform module to create set of DNS records in Cloudflare Hosted Zone.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | ~> 5.8 |
+| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | 5.8.2 |
 
 <!-- TFDOCS_PROVIDER_END -->
 
@@ -29,7 +29,7 @@ Terraform module to create set of DNS records in Cloudflare Hosted Zone.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | ~> 5.8 |
+| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | 5.8.2 |
 
 <!-- TFDOCS_REQUIREMENTS_END -->
 

--- a/examples/records/README.md
+++ b/examples/records/README.md
@@ -51,7 +51,7 @@ records = {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | ~> 5.8 |
+| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | 5.8.2 |
 
 ## Providers
 

--- a/examples/records/versions.tf
+++ b/examples/records/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 5.8"
+      version = "5.8.2"
     }
   }
   required_version = "~> 1.3"

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 5.8"
+      version = "5.8.2"
     }
   }
   required_version = "~> 1.3"


### PR DESCRIPTION
Bugs in provider do not allow to use the latest version:

- https://github.com/cloudflare/terraform-provider-cloudflare/issues/5957
- https://github.com/cloudflare/terraform-provider-cloudflare/issues/6009

Even with imported CAA records with provider `v5.8.4` you get a following error:

```
  ╷
  │ Error: Value is not one of the allowed types
  │ 
  │   with cloudflare_dns_record.this["2d48002bac12639bb21a750005b15323"],
  │   on main.tf line 1, in resource "cloudflare_dns_record" "this":
  │    1: resource "cloudflare_dns_record" "this" {
  │ 
  │ The following types are allowed: basetypes.Float64Type,
  │ basetypes.StringType
  ╵
  
  exit status 1
  ```